### PR TITLE
Add option to hide the list when everything fits on one screen

### DIFF
--- a/lib/alphabet_list_scroll_view.dart
+++ b/lib/alphabet_list_scroll_view.dart
@@ -31,6 +31,7 @@ class AlphabetListScrollView extends StatefulWidget {
   final TextStyle normalTextStyle;
   final bool showPreview;
   final bool keyboardUsage;
+  final bool showWhenNoScroll;
   final List<AlphabetScrollListHeader> headerWidgetList;
 
   const AlphabetListScrollView(
@@ -42,7 +43,8 @@ class AlphabetListScrollView extends StatefulWidget {
       this.showPreview = false,
         this.headerWidgetList = const [],
         @required this.indexedHeight,
-        this.keyboardUsage = false})
+        this.keyboardUsage = false,
+        this.showWhenNoScroll = true})
       : super(key: key);
 
   @override
@@ -71,6 +73,7 @@ class _AlphabetListScrollViewState extends State<AlphabetListScrollView> {
   var totalHeight = 0.0;
   var heightList = <double>[];
   double maxLimit = 0;
+  bool fitsOnScreen = false;
   List<_SpecialHeaderAlphabet> specialList = [];
 
   List<String> strList = [];
@@ -145,8 +148,10 @@ class _AlphabetListScrollViewState extends State<AlphabetListScrollView> {
     double maxLimit;
     if (totalHeight - screenHeight > 0) {
       maxLimit = totalHeight - screenHeight;
+      fitsOnScreen = false;
     } else {
       maxLimit = 0;
+      fitsOnScreen = true;
     }
     heightMap.forEach((k, v) {
       if (v > maxLimit) {
@@ -352,7 +357,7 @@ class _AlphabetListScrollViewState extends State<AlphabetListScrollView> {
               )
             ],
           ),
-          if (widget.showPreview)
+          if (widget.showPreview && (widget.showWhenNoScroll || !fitsOnScreen))
             IgnorePointer(
               child: AnimatedOpacity(
                 opacity: _visible ? 1.0 : 0.0,
@@ -370,7 +375,8 @@ class _AlphabetListScrollViewState extends State<AlphabetListScrollView> {
                 ),
               ),
             ),
-          _AlphabetListScollView(
+          if (widget.showWhenNoScroll || !fitsOnScreen)
+            _AlphabetListScollView(
             insideKey: _sideKey,
             specialHeader: widget.headerWidgetList.isNotEmpty,
             specialList: specialList,


### PR DESCRIPTION
Hi, please have a look if you like this idea. The few lines of code add an option to hide the bar with letters if not so many items are drawn that the whole screen is filled and one has to scroll. I left the default with the same behaviour as it is now.