### PR TITLE
Fix FutureOr error

### DIFF
--- a/lib/alphabet_list_scroll_view.dart
+++ b/lib/alphabet_list_scroll_view.dart
@@ -271,7 +271,7 @@ class _AlphabetListScrollViewState extends State<AlphabetListScrollView> {
   }
 
   _select(int index) async {
-    if (await (Vibration.hasVibrator() as FutureOr<bool>)) {
+    if (await (Vibration.hasVibrator() as Future<bool?>) ?? false) {
       Vibration.vibrate(duration: 20);
     }
     var height = heightMap[alphabetList[index]]!;


### PR DESCRIPTION
When clicking a letter, a cast error was thrown. This fixes that error and sets the default boolean of hasVibrator to false.